### PR TITLE
Fixed 'how to contribute' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ provides simple access to the Reddit API. DRAW is inspired by
 [PRAW](https://github.com/praw-dev/praw), the Python Reddit API Wrapper, and
 aims to also maintain a similar interface.
  
-Want to get involved? Check out [how to contribute](https://github.com/draw-dev/DRAW/CONTRIBUTING.md) to get started!
+Want to get involved? Check out [how to contribute](https://github.com/draw-dev/DRAW/blob/master/CONTRIBUTING.md) to get started!
 
 Disclaimer: This is not an official Google product.
 


### PR DESCRIPTION
Rather minor one, but the `how to contribute` link isn't linked correctly :) 

Great library by the way! :D 