### PR TITLE
0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 Change Log
 =================================
+
+## Version 0.6.0 (2019/07/08)
+
+### Breaking changes:
+* `Reddit.restoreAuthenticatedInstance` now returns `Reddit` instead of `Future<Reddit>`.
+
+### Other changes:
+* `Reddit.restoreAuthenticatedInstance` no longer throws an exception when not provided a
+  `clientSecret`. A `clientSecret` is still required for most client types except for
+  installed applications.
+* Updated dependencies.
+
 ## Version 0.5.2+1 (2019/05/31)
 * Updated documentation.
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ main() async {
     await writeCredentials(reddit.auth.credentials.toJson());
   } else {
     // Create a new Reddit instance using previously cached credentials.
-    reddit = await Reddit.restoreAuthenticatedInstance(
+    reddit = Reddit.restoreAuthenticatedInstance(
         userAgent: userAgent,
         configUri: configUri,
         credentialsJson: credentialsJson);

--- a/lib/src/reddit.dart
+++ b/lib/src/reddit.dart
@@ -318,7 +318,7 @@ class Reddit {
   ///
   /// [siteName] is the name of the configuration to use from draw.ini. Defaults
   /// to 'default'.
-  static Future<Reddit> restoreAuthenticatedInstance(String credentialsJson,
+  static Reddit restoreAuthenticatedInstance(String credentialsJson,
       {String clientId,
       String clientSecret,
       String userAgent,
@@ -326,11 +326,11 @@ class Reddit {
       Uri tokenEndpoint,
       Uri authEndpoint,
       Uri configUri,
-      String siteName = 'default'}) async {
+      String siteName = 'default'}) {
     if (credentialsJson == null) {
       throw DRAWArgumentError('credentialsJson cannot be null.');
     }
-    final reddit = Reddit._webFlowInstanceRestore(
+    return Reddit._webFlowInstanceRestore(
         clientId,
         clientSecret,
         userAgent,
@@ -340,11 +340,6 @@ class Reddit {
         authEndpoint,
         configUri,
         siteName);
-    final initialized = await reddit._initializedCompleter.future;
-    if (initialized) {
-      return reddit;
-    }
-    throw DRAWAuthenticationError('Unable to authenticate with Reddit');
   }
 
   Reddit._readOnlyInstance(
@@ -513,9 +508,6 @@ class Reddit {
 
     if (_config.clientId == null) {
       throw DRAWAuthenticationError('clientId cannot be null.');
-    }
-    if (_config.clientSecret == null) {
-      throw DRAWAuthenticationError('clientSecret cannot be null.');
     }
     if (_config.userAgent == null) {
       throw DRAWAuthenticationError('userAgent cannot be null.');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: draw
-version: 0.5.2+1
+version: 0.6.0
 description: 'A fully-featured Reddit API wrapper for Dart, inspired by PRAW.'
 homepage: 'https://github.com/draw-dev/DRAW'
 authors:

--- a/test/auth/web_auth.dart
+++ b/test/auth/web_auth.dart
@@ -123,7 +123,7 @@ Future<void> main() async {
     final creds = reddit.auth.credentials.toJson();
 
     // Attempt to create a new instance with the saved credentials.
-    final redditRestored = await Reddit.restoreAuthenticatedInstance(creds,
+    final redditRestored = Reddit.restoreAuthenticatedInstance(creds,
         clientId: kWebClientID,
         clientSecret: kWebClientSecret,
         userAgent: userAgent);


### PR DESCRIPTION
- Reddit.restoreAuthenticatedInstance now returns `Reddit` instead of
`Future<Reddit>`
- Reddit.restoreAuthenticatedInstance no longer requires a client secret
- Updated example and tests.

Fixes #147 and fixes #148 