### PR TITLE
Add the option to only expand a single instance of MoreComments

### DIFF
--- a/lib/src/models/comment_forest.dart
+++ b/lib/src/models/comment_forest.dart
@@ -98,12 +98,15 @@ class CommentForest {
   /// (default: 32), and [threshold] is the minimum number of comments that a
   /// [MoreComments] object needs to represent in order to be expanded (default:
   /// 0).
+  ///
+  /// If [specificMoreComment] (default: null) is not null, only expand that instance of [MoreComments]
   Future<void> replaceMore(
       {limit = 32, threshold = 0, MoreComments specificMoreComment}) async {
     var remaining = limit;
     final moreComments = _getMoreComments(_comments);
     final skipped = [];
 
+    // If [specificMoreComment] is specified, only do this and return
     if (specificMoreComment != null) {
       await _replaceOneMore(specificMoreComment);
       return;

--- a/lib/src/models/comment_forest.dart
+++ b/lib/src/models/comment_forest.dart
@@ -98,10 +98,16 @@ class CommentForest {
   /// (default: 32), and [threshold] is the minimum number of comments that a
   /// [MoreComments] object needs to represent in order to be expanded (default:
   /// 0).
-  Future<void> replaceMore({limit = 32, threshold = 0}) async {
+  Future<void> replaceMore(
+      {limit = 32, threshold = 0, MoreComments specificMoreComment}) async {
     var remaining = limit;
     final moreComments = _getMoreComments(_comments);
     final skipped = [];
+
+    if (specificMoreComment != null) {
+      await _replaceOneMore(specificMoreComment);
+      return;
+    }
 
     while (moreComments.isNotEmpty) {
       final moreComment = moreComments.removeFirst();
@@ -130,6 +136,15 @@ class CommentForest {
       newComments.forEach(_insertComment);
       _removeMore(moreComment);
     }
+  }
+
+  Future<void> _replaceOneMore(MoreComments moreComment) async {
+    final newComments = await moreComment.comments(update: false);
+    for (final more in _getMoreComments(newComments, _comments)?.toList()) {
+      setSubmissionInternal(more, _submission);
+    }
+    newComments.forEach(_insertComment);
+    _removeMore(moreComment);
   }
 
   static final _kNoParent = null;

--- a/lib/src/models/mixins/voteable.dart
+++ b/lib/src/models/mixins/voteable.dart
@@ -81,4 +81,48 @@ mixin VoteableMixin implements RedditBaseInitializedMixin {
   /// voting by bots). See Reddit rules for more details on what is considered
   /// vote cheating or manipulation.
   Future<void> upvote() async => _vote('1');
+
+
+
+  Future<void> _riskyVote(String direction) async {
+    switch (direction) {
+      case '0':
+        data['likes'] = null;
+        break;
+      case '1':
+        data['likes'] = true;
+        break;
+      case '-1':
+        data['likes'] = false;
+    }
+    await reddit.post(apiPath['vote'], {'dir': direction, 'id': fullname},
+      discardResponse: true);
+  }
+
+  /// Clear the authenticated user's vote on the object.
+  /// Does **not** waitfor the post request to be resolved before updating the local object
+  ///
+  /// Note: votes must be cast on behalf of a human user (i.e., no automatic
+  /// voting by bots). See Reddit rules for more details on what is considered
+  /// vote cheating or manipulation.
+  Future<void> riskyClearVote() async => _riskyVote('0');
+    /// Casts a downvote for the authenticated user's vote on the object.
+  /// Does **not** wait for the post request to be resolved before updating the local object
+  ///
+  /// Note: votes must be cast on behalf of a human user (i.e., no automatic
+  /// voting by bots). See Reddit rules for more details on what is considered
+  /// vote cheating or manipulation.
+  Future<void> riskyDownvote() async => _riskyVote('-1');
+  /// Casts an upvote for the authenticated user's vote on the object.
+  /// Does **not** wait for the post request to be resolved before updating the local object
+  ///
+  /// Note: votes must be cast on behalf of a human user (i.e., no automatic
+  /// voting by bots). See Reddit rules for more details on what is considered
+  /// vote cheating or manipulation.
+  Future<void> friskyUpvote() async => _riskyVote('1');
+
+
+
+
+
 }

--- a/lib/src/models/mixins/voteable.dart
+++ b/lib/src/models/mixins/voteable.dart
@@ -119,7 +119,7 @@ mixin VoteableMixin implements RedditBaseInitializedMixin {
   /// Note: votes must be cast on behalf of a human user (i.e., no automatic
   /// voting by bots). See Reddit rules for more details on what is considered
   /// vote cheating or manipulation.
-  Future<void> friskyUpvote() async => _riskyVote('1');
+  Future<void> riskyUpvote() async => _riskyVote('1');
 
 
 

--- a/lib/src/models/mixins/voteable.dart
+++ b/lib/src/models/mixins/voteable.dart
@@ -46,9 +46,14 @@ mixin VoteableMixin implements RedditBaseInitializedMixin {
     }
   }
 
-  Future<void> _vote(String direction) async {
-    await reddit.post(apiPath['vote'], {'dir': direction, 'id': fullname},
+  Future<void> _vote(String direction, bool waitForResponse) async {
+    final response = reddit.post(
+        apiPath['vote'], {'dir': direction, 'id': fullname},
         discardResponse: true);
+    if (waitForResponse) {
+      await response;
+    }
+
     switch (direction) {
       case '0':
         data['likes'] = null;
@@ -66,63 +71,22 @@ mixin VoteableMixin implements RedditBaseInitializedMixin {
   /// Note: votes must be cast on behalf of a human user (i.e., no automatic
   /// voting by bots). See Reddit rules for more details on what is considered
   /// vote cheating or manipulation.
-  Future<void> clearVote() async => _vote('0');
+  Future<void> clearVote({bool waitForResponse = true}) async =>
+      _vote('0', waitForResponse);
 
   /// Clear the authenticated user's vote on the object.
   ///
   /// Note: votes must be cast on behalf of a human user (i.e., no automatic
   /// voting by bots). See Reddit rules for more details on what is considered
   /// vote cheating or manipulation.
-  Future<void> downvote() async => _vote('-1');
+  Future<void> downvote({bool waitForResponse = true}) async =>
+      _vote('-1', waitForResponse);
 
   /// Clear the authenticated user's vote on the object.
   ///
   /// Note: votes must be cast on behalf of a human user (i.e., no automatic
   /// voting by bots). See Reddit rules for more details on what is considered
   /// vote cheating or manipulation.
-  Future<void> upvote() async => _vote('1');
-
-
-
-  Future<void> _riskyVote(String direction) async {
-    switch (direction) {
-      case '0':
-        data['likes'] = null;
-        break;
-      case '1':
-        data['likes'] = true;
-        break;
-      case '-1':
-        data['likes'] = false;
-    }
-    await reddit.post(apiPath['vote'], {'dir': direction, 'id': fullname},
-      discardResponse: true);
-  }
-
-  /// Clear the authenticated user's vote on the object.
-  /// Does **not** waitfor the post request to be resolved before updating the local object
-  ///
-  /// Note: votes must be cast on behalf of a human user (i.e., no automatic
-  /// voting by bots). See Reddit rules for more details on what is considered
-  /// vote cheating or manipulation.
-  Future<void> riskyClearVote() async => _riskyVote('0');
-    /// Casts a downvote for the authenticated user's vote on the object.
-  /// Does **not** wait for the post request to be resolved before updating the local object
-  ///
-  /// Note: votes must be cast on behalf of a human user (i.e., no automatic
-  /// voting by bots). See Reddit rules for more details on what is considered
-  /// vote cheating or manipulation.
-  Future<void> riskyDownvote() async => _riskyVote('-1');
-  /// Casts an upvote for the authenticated user's vote on the object.
-  /// Does **not** wait for the post request to be resolved before updating the local object
-  ///
-  /// Note: votes must be cast on behalf of a human user (i.e., no automatic
-  /// voting by bots). See Reddit rules for more details on what is considered
-  /// vote cheating or manipulation.
-  Future<void> riskyUpvote() async => _riskyVote('1');
-
-
-
-
-
+  Future<void> upvote({bool waitForResponse = true}) async =>
+      _vote('1', waitForResponse);
 }


### PR DESCRIPTION
I didn't see a way to expand a single instance of MoreComments. CommentForest would expand a number of MoreComments given by a parameter. I added a `specificMoreComment` parameter to  `replaceMore()`  expand that single instance.