### PR TITLE
added option to expand only one instance of MoreComments

### DIFF
--- a/lib/src/models/comment_forest.dart
+++ b/lib/src/models/comment_forest.dart
@@ -98,10 +98,19 @@ class CommentForest {
   /// (default: 32), and [threshold] is the minimum number of comments that a
   /// [MoreComments] object needs to represent in order to be expanded (default:
   /// 0).
-  Future<void> replaceMore({limit = 32, threshold = 0}) async {
+  ///
+  /// If [specificMoreComments] is provided replaceMore() will only expand the given
+  /// [MoreComments] and return after that one has been expanded
+  Future<void> replaceMore(
+      {limit = 32, threshold = 0, MoreComments specificMoreComments}) async {
     var remaining = limit;
     final moreComments = _getMoreComments(_comments);
     final skipped = [];
+
+    if (specificMoreComments != null) {
+      await _replaceOneMore(specificMoreComments);
+      return;
+    }
 
     while (moreComments.isNotEmpty) {
       final moreComment = moreComments.removeFirst();
@@ -130,6 +139,15 @@ class CommentForest {
       newComments.forEach(_insertComment);
       _removeMore(moreComment);
     }
+  }
+
+  Future<void> _replaceOneMore(MoreComments moreComment) async {
+    final newComments = await moreComment.comments(update: false);
+    for (final more in _getMoreComments(newComments, _comments)?.toList()) {
+      setSubmissionInternal(more, _submission);
+    }
+    newComments.forEach(_insertComment);
+    _removeMore(moreComment);
   }
 
   static final _kNoParent = null;


### PR DESCRIPTION
Added the option in `replaceMore()` to expand only a single instance of MoreComments.

MoreComments is able to get its children, but when a client calls children() on MoreComments, those new Comments are removed from the CommentForest. So it makes sense that CommentForest it able to add new children to itself.