### PR TITLE
Fix type error when creating untrusted instance

### DIFF
--- a/lib/src/auth.dart
+++ b/lib/src/auth.dart
@@ -270,14 +270,17 @@ abstract class Authenticator {
 
     final httpClient = http.Client();
     final start = DateTime.now();
-    final headers = <String, String?>{};
-    headers[_kUserAgentKey] = _config.userAgent;
-    headers[_kAuthorizationKey] =
-        'Basic ${base64Encode((clientId + ":").codeUnits)})';
+    final headers = <String, String>{
+      _kAuthorizationKey: 'Basic ${base64Encode((clientId + ":").codeUnits)})',
+      if (_config.userAgent != null) _kUserAgentKey: _config.userAgent!
+    };
 
     // Request the token from the server.
-    final response = await httpClient.post(_grant.tokenEndpoint,
-        headers: headers as Map<String, String>?, body: accountInfo);
+    final response = await httpClient.post(
+      _grant.tokenEndpoint,
+      headers: headers,
+      body: accountInfo,
+    );
 
     // Check for error response.
     final responseMap = json.decode(response.body);


### PR DESCRIPTION
This fixes: https://github.com/draw-dev/DRAW/issues/195

I get a config error when trying to run the tests locally but I believe the reason that the `'read-only untrusted'`-testcase is not failing in Travis is because the tests are run with `--no-sound-null-safety`, which is not a great idea IMHO.