### PR TITLE
Added 'raw_json' param to api calls.

### DIFF
--- a/lib/src/reddit.dart
+++ b/lib/src/reddit.dart
@@ -620,6 +620,7 @@ class Reddit {
           'Cannot make requests using unauthenticated client.');
     }
     final path = Uri.https(defaultOAuthApiEndpoint, api);
+    params ??= {'raw_json': '1'}; // only on null
     final response =
         await auth.get(path, params: params, followRedirects: followRedirects);
     return objectify ? _objector.objectify(response) : response;


### PR DESCRIPTION
Fixes issues with encoded URIs and gives way more data with each call.

Notably the issue with icon images containing '&amp;', making it hard to open images in browser/load them.